### PR TITLE
fix: gsuite event creator

### DIFF
--- a/.holo/sources/slate-connector-gsuite.toml
+++ b/.holo/sources/slate-connector-gsuite.toml
@@ -1,3 +1,3 @@
 [holosource]
 url = "https://github.com/SlateFoundation/slate-connector-gsuite"
-ref = "refs/tags/v0.0.2"
+ref = "refs/tags/v0.0.3"

--- a/html-templates/sections/courseSection.tpl
+++ b/html-templates/sections/courseSection.tpl
@@ -129,7 +129,7 @@
                 </section>
 
                 {template linksEntry entry}
-                    {if $entry.href}<a href="{$entry.href|escape}">{/if}
+                    {if $entry.href}<a href="{$entry.href|escape}" {$entry.attribs}>{/if}
                         {$entry.label|escape}
                     {if $entry.href}</a>{/if}
                 {/template}


### PR DESCRIPTION
- fix: add support for gsuite section event creator
- chore: bump slate-connector-gsuite to v0.0.3