### PR TITLE
feat: add cypress testing

### DIFF
--- a/.github/workflows/cypress-tests.yml
+++ b/.github/workflows/cypress-tests.yml
@@ -1,0 +1,73 @@
+name: Cypress Tests
+
+on: pull_request
+
+jobs:
+  cypress-tests:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Initialize Chef Habitat artifacts cache directory
+      run: |
+        sudo mkdir -p /hab/cache/artifacts
+        sudo chown runner:docker -R /hab
+    - name: Cache Chef Habitat artifacts
+      uses: actions/cache@v1
+      with:
+        path: /hab/cache/artifacts
+        key: hab-cache-artifacts
+    - uses: actions/checkout@v2
+    # TODO: wrap the next three steps an an emergence-studio action
+    - name: 'Stop default mysql service'
+      run: sudo service mysql stop
+    - name: 'Initialize Chef Habitat environment'
+      uses: JarvusInnovations/habitat-action@master
+      env:
+        HAB_LICENSE: accept
+        HAB_NGINX: |
+          [http.listen]
+          port = 7080
+        HAB_MYSQL: |
+          app_username = 'appadmin'
+          app_password = 'appadmin'
+          bind = '0.0.0.0'
+        HAB_PHP_RUNTIME: |
+          [sites.default.holo]
+          gitDir = '${{ github.workspace }}/.git'
+      with:
+        deps: |
+          jarvus/hologit
+        supervisor: |
+          core/mysql
+          emergence/php-runtime --bind="database:mysql.default"
+          emergence/nginx --bind="backend:php-runtime.default"
+    - name: Load site projection into emergence runtime
+      env:
+        HOLO_CACHE_FROM: origin
+        HOLO_CACHE_TO: origin
+      run: |
+        until sudo test -f /hab/svc/php-runtime/config/fpm-exec; do sleep .1; done
+        SITE_TREE="$(hab pkg exec jarvus/hologit git-holo project emergence-site)"
+        [ -n "${SITE_TREE}" ] || exit 1
+        sudo hab pkg exec emergence/php-runtime emergence-php-load "${SITE_TREE}"
+        sudo chown runner:docker -R /hab/cache/artifacts
+    - name: Set up Cypress workspace
+      run: |
+        CYPRESS_TREE="$(hab pkg exec jarvus/hologit git-holo project cypress-workspace)"
+        [ -n "${CYPRESS_TREE}" ] || exit 1
+        mkdir "${GITHUB_WORKSPACE}.cypress-workspace"
+        git archive --format=tar "${CYPRESS_TREE}" | (cd "${GITHUB_WORKSPACE}.cypress-workspace" && tar xf -)
+    - name: Run Cypress tests
+      uses: cypress-io/github-action@v1
+      with:
+        env: STUDIO_CONTAINER=,STUDIO_SSH=
+        working-directory: ${{ github.workspace }}.cypress-workspace
+    - uses: actions/upload-artifact@v1
+      if: failure()
+      with:
+        name: cypress-screenshots
+        path: ${{ github.workspace }}.cypress-workspace/cypress/screenshots
+    - uses: actions/upload-artifact@v1
+      if: always()
+      with:
+        name: cypress-videos
+        path: ${{ github.workspace }}.cypress-workspace/cypress/videos

--- a/.holo/branches/cypress-workspace/_scienceleadership-skeleton.toml
+++ b/.holo/branches/cypress-workspace/_scienceleadership-skeleton.toml
@@ -1,0 +1,3 @@
+[holomapping]
+files = "cypress/**"
+after = "*"

--- a/.holo/branches/cypress-workspace/_slate.toml
+++ b/.holo/branches/cypress-workspace/_slate.toml
@@ -1,0 +1,11 @@
+[holomapping]
+files = [
+    "package.json",
+    "package-lock.json",
+    "cypress.json",
+    "cypress/**",
+
+    # ignore fixtures submodule
+    "!cypress/fixtures/database"
+]
+before = "*"

--- a/.holo/branches/cypress-workspace/cypress/fixtures/database.toml
+++ b/.holo/branches/cypress-workspace/cypress/fixtures/database.toml
@@ -1,0 +1,3 @@
+[holomapping]
+holosource = "slate-fixtures"
+files = "*.sql"

--- a/.holo/sources/slate-fixtures.toml
+++ b/.holo/sources/slate-fixtures.toml
@@ -1,0 +1,3 @@
+[holosource]
+url = "https://github.com/SlateFoundation/slate-fixtures.git"
+ref = "refs/heads/cbl/demo"


### PR DESCRIPTION
Haven't tested this yet, first pass at copying in workflow from `b21-skeleton`

## TODO

- [ ] the `slate` upstream doesn't have any cypress scaffolding like `slate-cbl` does. we need to refactor the cypress scaffolding in `slate-cbl` and move most of it to `slate` so `slate-cbl` is just an overlay like `b21-skeleton` and this will be (and then make `b21-skeleton` work again as a 2nd-level overlay)